### PR TITLE
Remove redundant npm dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "express": "^4.17.1",
     "http-status-codes": "^1.3.2",
     "install": "^0.12.2",
-    "npm": "^6.9.0",
     "reflect-metadata": "^0.1.13",
     "sqlite3": "^4.0.9",
     "tsconfig-paths": "^3.8.0",


### PR DESCRIPTION

Hello meijin007!

It seems like you have npm as one of your (dev-) dependency in story-line.
Since you actually need npm to install the dependencies it's redundant to
have npm itself as (dev-) dependency. 

Therefore I've removed it and made this PR, merge if you want :)
Be sure to re-run `npm i` or `yarn` to actualize your lock files.

Beep boop, I'm a bot.
